### PR TITLE
Add North Carolina scraper

### DIFF
--- a/R/webscraping_state_info.R
+++ b/R/webscraping_state_info.R
@@ -420,6 +420,22 @@ get_nj_covid_data <- function(nj_doc_path) {
                 state = "New Jersey"))
 }
 
+# North Carolina --------------------------------------------------------------
+get_nc_covid_data <- function(nc_doc_path) {
+  column_totals <- nc_doc_path %>%
+    html_nodes('.DPSDITDOPCovidInformation') %>%
+    html_nodes('.columntotal') %>%
+    html_text() %>%
+    str_trim()
+  # There are 8 "column total" entries; the last three are Tests Performed, Positive, Negative
+  total_tests <- as.integer(column_totals[6])
+  total_positives <- as.integer(column_totals[7])
+  total_negatives <- as.integer(column_totals[8])
+
+  tibble(inmates_positive=total_positives, inmates_negative=total_negatives, inmates_tested=total_tests) %>%
+    mutate(scrape_date = today(), state = 'North Carolina')
+}
+
 # North Dakota ------------------------------------------------------------
 #this function is probably the most likely to break
 get_nd_covid_data <- function(nd_doc_path) {


### PR DESCRIPTION
I didn't add it to `make_covid_data.R`, wasn't sure if you wanted to check it out before doing that. Also I updated the spreadsheet to point at the iframe that contains the data, rather than the main page:

https://www.ncdps.gov/our-organization/adult-correction/prisons/prisons-info-covid-19
embeds an iframe:
https://opus.doc.state.nc.us/DOPCovid19Stats/services/facilitystatsServlet

and the iframe has the actual data. So this parsing code assumes it's reading from the iframe. Let me know if the naming conventions aren't right, NC only provides number of pos, number of neg, and total number of people tested.