### PR TITLE
Fix Vermont for new image; just report simplest data

### DIFF
--- a/R/webscraping_state_info.R
+++ b/R/webscraping_state_info.R
@@ -684,10 +684,10 @@ get_michigan_data <- function(michigan_medium_page) {
 
 
 # Vermont --------------------------------------------------------------------
-get_vermont_covid_data <- function(vermont_doc_path) {
+get_vermont_covid_data <- function(vermont_html) {
   # As of 4/20/20, there are two imgs on the page - the first one contains data about incarcerated people, the
   # second about staff
-  imgs <- vermont_doc_path %>%
+  imgs <- vermont_html %>%
     html_nodes("img") %>%
     html_attr("src")
   inmate_data_img_src <- imgs[1]
@@ -740,9 +740,6 @@ get_vermont_covid_data <- function(vermont_doc_path) {
          inmates_negative=total_negatives,
          inmates_pending=pending_results,
          inmates_tested=total_tests,
-         inmates_medical_isolation=inmates_medical_isolation,
-         inmates_released_medical_isolation=inmates_released_medical_isolation,
-         inmates_hospital=inmates_hospital,
          staff_positive=num_staff_positive) %>%
     mutate(scrape_date = today(), state = 'Vermont')
 }


### PR DESCRIPTION
Old image from a week ago:
![vermont_inmate_report_2020_04_19](https://user-images.githubusercontent.com/503781/80314488-5ac75800-87b7-11ea-854c-162bb0ca9c4a.png)

Image from today:
![vermont_2020_04_26](https://user-images.githubusercontent.com/503781/80314495-5ef37580-87b7-11ea-9a22-9393cf84b24a.png)

which is parsed correctly for the more limited set of fields:
```
get_vermont_covid_data(read_html('https://doc.vermont.gov/covid-19-information-page'))
# A tibble: 1 x 7
  inmates_positive inmates_negative inmates_pending inmates_tested staff_positive scrape_date state  
             <int>            <int>           <int>          <int>          <int> <date>      <chr>  
1               38              184               0            222             18 2020-04-26  Vermont
```

let me know what you all think is best here. The main numbers (total # tested, total positive, total negative, and total pending) are in the same place of the table, but I just removed all the other fields in case they keep changing - seems best to err on the side of getting those fields right and not reporting potentially wrong/changing data for the other ones. open to other ideas though